### PR TITLE
WL-3065 Remove oxford WebDAV instructions as unneeded.

### DIFF
--- a/content-tool/tool/src/webapp/vm/content/chef_resources_webdav.vm
+++ b/content-tool/tool/src/webapp/vm/content/chef_resources_webdav.vm
@@ -74,24 +74,6 @@
 		<p>$tlang.getString("dav.graf1").</p>
 		<p>$tlang.getString("dav.graf2") <strong>$tlang.getString("dav.graf3")</strong>. $tlang.getString("dav.graf4").</p>
 		<p>$tlang.getString("dav.graf5") <strong>$tlang.getString("dav.graf6")</strong> $tlang.getString("dav.graf7") <strong>$tlang.getString("dav.graf8")</strong> $tlang.getString("dav.graf9").</p>
-		
-		<h4>Setting up your WebLearn WebDAV account</h4> 
-		<p>How you connect using WebDAV, depends on how you login to WebLearn:</p>
-		<ul>
-			<li>
-				<strong>Oxford Account</strong>: If you login via the <em>Oxford Account</em> link, i.e. you have an Oxford (WebAuth) account, then you can use the same	user name and password in order to connect via WebDAV.
-			</li> 
-			<li>
-				<strong>Other Users</strong>: If you login via the <em>Other Users</em> link, you can use the same user name and password to connect via WebDAV. If this takes the form of an e-mail address and appears not to work, then you should follow the procedure described below to get a new user name that consists of just alphanumeric characters.
-				<ul style="font-size: smaller;"> 
-					<li>
-						E-mail <a href="mailto:weblearn@oucs.ox.ac.uk">weblearn@oucs.ox.ac.uk</a> and request a user name for the purposes of using WebDAV. Include your current user name in the e-mail (your new WebDAV user name will be 	based on this). If you have a non-Oxford e-mail address, i.e. one that doesn't end in .ox.ac.uk, then include this in the e-mail and we will associate this with the user name. This is optional, but if for any reason you forgot your password, you would be able to reset it yourself rather than have to ask us to do it for you. Once this new user name has been created, 	you can add it as a participant to the site in the <code>maintain</code> role.
-					</li>
-				</ul>
-			</li>
-		</ul>
-		
-		
 		<div id="davdocs_step1">
 			<p><strong>$tlang.getString("dav.graf10") - </strong> $tlang.getString("dav.graf11"):</p>
 


### PR DESCRIPTION
The webdav instructions aren't needed and so can be removed. This cleanup happened because we had an old email address in the instructions.
I successfully connected to a Sakai WebDAV share using Windows XP SP2 with a username containing a @ character.
