### PR TITLE
WL-3105 Changing wording on Oxford users

### DIFF
--- a/content-bundles/resources/content.properties
+++ b/content-bundles/resources/content.properties
@@ -42,7 +42,7 @@ access.dropbox1	= Visible to instructor and student
 # Definitions for roles based on their ids. .anon is the roleid for pubview / public access.
 # Could get these names RoleProvider#getDisplayName(roleId)
 access.role.anon = Public
-access.role.uk.ac.ox.bod.allusers = Oxford members
+access.role.uk.ac.ox.bod.allusers = Oxford users
 
 # Descriptors for two roles and multiple roles
 access.roleLabel.two = {0} and {1}

--- a/content-bundles/resources/types.properties
+++ b/content-bundles/resources/types.properties
@@ -22,8 +22,8 @@ access.site.noparent	 = Resources in this folder can be viewed by <strong>all me
 access.role.anon.choice	 = This file is <strong>publicly viewable</strong>.
 access.role.anon.fldr	 = This folder and its contents are <strong>publicly viewable</strong>.
 
-access.role.uk.ac.ox.bod.allusers.choice	 = This file is <strong>viewable by all Oxford members</strong>.
-access.role.uk.ac.ox.bod.allusers.fldr		 = This folder and its contents are <strong>viewable by all Oxford members</strong>.
+access.role.uk.ac.ox.bod.allusers.choice	 = This file is <strong>viewable by all Oxford users</strong>.
+access.role.uk.ac.ox.bod.allusers.fldr		 = This folder and its contents are <strong>viewable by all Oxford users</strong>.
 
 access.inherited	 = (Inherited)
 access.dropbox		 = Dropbox


### PR DESCRIPTION
When setting up role based access we introduced a different wording for
All Oxford Users. This commit changes the wording 'all Oxford members' to
'all Oxford users'.
