### PR TITLE
WL-3167 Allow users to add strict doctype.

### DIFF
--- a/content-bundles/resources/types.properties
+++ b/content-bundles/resources/types.properties
@@ -240,6 +240,7 @@ props.deletime		 = Deleted
 props.automatic		 = Automatic
 props.always		 = Always
 props.never		 = Never
+props.standards		= Always (standards)
 # Should be improved when velocity is upgraded (can do getFormattedMessage())
 props.html_filter    = Use WebLearn styles
 props.mime		 = File Type

--- a/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
+++ b/content-tool/tool/src/webapp/vm/resources/sakai_properties.vm
@@ -595,6 +595,7 @@
 						<select name="html_filter${DOT}$i" size="1">
 							<option value="auto"#if($item.htmlFilter == "auto")selected="yes"#end>$tlang.getString("props.automatic")</option>
 							<option value="yes" #if($item.htmlFilter == "yes")selected="yes"#end>$tlang.getString("props.always")</option>
+							<option value="standards" #if($item.htmlFilter == "standards")selected="yes"#end>$tlang.getString("props.standards")</option>
 							<option value="no" #if($item.htmlFilter == "no")selected="yes"#end>$tlang.getString("props.never")</option>
 						</select>
 					</td>


### PR DESCRIPTION
Users can optionally have a strict doctype added to their HTML to force the browser out of quirks mode.
