### PR TITLE
WL-3418 : webDAV URL wrong if Email Archive tool is on site

### DIFF
--- a/content-tool/tool/src/webapp/vm/content/chef_resources_webdav.vm
+++ b/content-tool/tool/src/webapp/vm/content/chef_resources_webdav.vm
@@ -85,8 +85,6 @@ ${server_url}${dav_user}$user_id
 ${server_url}${dav_group_user}$site_id
 #elseif("$!dropboxMode" == "true")
 ${server_url}${dav_group_user}$site_id/$user_id
-#elseif("${site_alias}" != "")
-${server_url}${dav_group}${site_alias}
 #else
 ${server_url}${dav_group}$site_id
 #end


### PR DESCRIPTION
remove mention of email archive site alias in web url generation
