### PR TITLE
WL-3846 - reviseMimeType was null and defaulted to app/bin

### DIFF
--- a/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
+++ b/content-tool/tool/src/java/org/sakaiproject/content/tool/ResourcesAction.java
@@ -3538,6 +3538,7 @@ protected static final String PARAM_PAGESIZE = "collections_per_page";
 				}
 			}
 			// update mimetype
+			pipe.setRevisedMimeType(pipe.getMimeType());
 			edit.setContentType(pipe.getRevisedMimeType());
 			ContentHostingService.commitResource(edit, pipe.getNotification());
 		}


### PR DESCRIPTION
reviseMimeType is set while updating resource items like txt files but its never set during updation of reading list .It was always null causing edit to get value of app/binary on update.
Hence reviseMimeType for the pipe has been set just before doing update for edit content type
