### PR TITLE
WL-4003 Mutiple files can be added to a Lessons page.

### DIFF
--- a/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
+++ b/content-tool/tool/src/java/org/sakaiproject/content/tool/FilePickerAction.java
@@ -722,8 +722,18 @@ public class FilePickerAction extends PagedResourceHelperAction
 				{
 					items = filterList(items, filter);
 				}
+				//Check if the ListItem in 'items' matches with the attach_item in the new_items list , if yes then it should not have option to be selected.
+				for(Object new_item : new_items){
+					for(ListItem listItem : items){
+						if(listItem.getId().equals(((AttachItem)new_item).getId())){
+							listItem.setCanSelect(false);
+							break;
+						}
+
+					}
+				}
 				this_site.addAll(items);
-				
+
 			}
 			
 			context.put ("this_site", this_site);


### PR DESCRIPTION
Checking for the selected item and then setting the 'canSelect' property
false so that is is not selected again. This fix is linked to pull request https://github.com/ox-it/wl-lessonbuilder/commit/b7164ff10f77e8b6490d1416bad3c69954693c3b
