### PR TITLE
WL-4259 Added 'Continue' and 'Cancel' buttons on Resources browse list

### DIFF
--- a/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
+++ b/content-tool/tool/src/webapp/vm/content/sakai_filepicker_select.vm
@@ -148,6 +148,14 @@ $(document).ready(function() {
 						</tr>
 					#end
 			</table>
+			<p class="act" >
+				<input type="button" name="attachButton" id="attachButton" accesskey="s"
+					onclick="javascript: document.getElementById('attachForm').action='#toolLink("ResourcesAction" "doAddattachments")'; submitform('attachForm');"
+					value="$tlang.getString("att.finish")" #if($list_has_changed) class="active" #else disabled="disabled" #end />
+				<input type="button" name="cancelButton" id="cancelButton" accesskey="x"
+					onclick="javascript: document.getElementById('attachForm').action='#toolLink("ResourcesAction" "doCancel")'; submitform('attachForm');"
+					value="$tlang.getString("att.cancel")"  />
+			</p>
 		#end	
 		######################  Page Title / Breadcrumbs  ##############
 		<h3>


### PR DESCRIPTION
 when adding content to Lessons.

Have duplicated the button code in the 'sakai_filepicker_select.vm'.
Checked File Picker in tools like Assignments, Forums, Surveys, Forums,
Citations, Messages and Announcements.
